### PR TITLE
Support more binary GH assets

### DIFF
--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -14,7 +14,7 @@ import (
 	"github.com/ulikunitz/xz"
 )
 
-func Extract(fs fsh.FS, archivePath, destDir string) error {
+func Extract(fs fsh.FS, archivePath, destDir, binaryName string) error {
 	f, err := fs.Open(archivePath)
 	if err != nil {
 		return err
@@ -32,9 +32,35 @@ func Extract(fs fsh.FS, archivePath, destDir string) error {
 		return extractTar(fs, f, destDir, func(r io.Reader) (io.Reader, error) { return bzip2.NewReader(r), nil })
 	case ".tar.xz":
 		return extractTar(fs, f, destDir, func(r io.Reader) (io.Reader, error) { return xz.NewReader(r) })
+	case "":
+		return extractFile(fs, f, destDir, archivePath, binaryName)
 	}
 
 	return fmt.Errorf("unsupported archive type (%s)", ext)
+}
+
+func extractFile(fs fsh.FS, f afero.File, dest, archivePath, binaryName string) error {
+	if err := fs.MkdirAll(dest, 0o755); err != nil {
+		return err
+	}
+
+	target := filepath.Join(dest, binaryName)
+	out, err := fs.Create(target)
+	if err != nil {
+		return err
+	}
+	defer out.Close() //nolint:errcheck
+
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return err
+	}
+
+	if _, err = out.Write(data); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func extractZip(fs fsh.FS, f afero.File, dest string) error {

--- a/internal/workdir/runtimes/runtime-github-release/assets.go
+++ b/internal/workdir/runtimes/runtime-github-release/assets.go
@@ -82,6 +82,11 @@ func autoDiscoverAsset(assets []*github.ReleaseAsset, toolName, version, goos, g
 			regexp.QuoteMeta(toolName),
 			strings.Join(osNames, "|"),
 			strings.Join(archNames, "|")),
+		// Pattern 5: toolname_darwin_arm64
+		fmt.Sprintf(`(?i)^%s[-_](%s)[-_](%s)$`,
+			regexp.QuoteMeta(toolName),
+			strings.Join(osNames, "|"),
+			strings.Join(archNames, "|")),
 	}
 
 	for _, pattern := range patterns {

--- a/internal/workdir/runtimes/runtime-github-release/assets.go
+++ b/internal/workdir/runtimes/runtime-github-release/assets.go
@@ -54,6 +54,11 @@ func autoDiscoverAsset(assets []*github.ReleaseAsset, toolName, version, goos, g
 		"arm":   {"armv6", "armv7", "arm", "ARM"},
 	}[goarch]
 
+	if goos == "darwin" {
+		// xxx_darwin_all for multi-platform binaries
+		archNames = append([]string{"all"}, archNames...)
+	}
+
 	if len(osNames) == 0 || len(archNames) == 0 {
 		return nil, fmt.Errorf("unsupported local platform (%s/%s)", goos, goarch)
 	}

--- a/internal/workdir/runtimes/runtime-github-release/runtime_github_release.go
+++ b/internal/workdir/runtimes/runtime-github-release/runtime_github_release.go
@@ -114,7 +114,7 @@ func (r *Runtime) Install(ctx context.Context, program string) error {
 		return fmt.Errorf("download asset: %w", err)
 	}
 
-	if err := archive.Extract(r.fs, tmpFile, tmpDirUnarchived); err != nil {
+	if err := archive.Extract(r.fs, tmpFile, tmpDirUnarchived, repo); err != nil {
 		return fmt.Errorf("extract release file: %w", err)
 	}
 


### PR DESCRIPTION
- Adds support for downloading un-packaged binaries from github assets.

ex: https://github.com/telepresenceio/telepresence/releases/download/v2.27.4/telepresence-darwin-arm64

```json
{
	"runtime": "gh",
	"module": "telepresenceio/telepresence@v2.27.4",
	"alias": null,
	"tags": null
}
```

```bash
$ toolset sync
Sync: gh telepresenceio/telepresence@v2.27.4 
```

- Adds support for multi-platform darwin binaries
 
ex: https://github.com/ryane/kfilt/releases/download/v1.0.0/kfilt_darwin_all
```json
{
	"runtime": "gh",
	"module": "ryane/kfilt@v1.0.0",
	"alias": null,
	"tags": null
}
```

```bash
$ toolset sync
Sync: gh ryane/kfilt@v1.0.0
```